### PR TITLE
fix: pnpm config flag

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -9,7 +9,7 @@ module.exports = async (npmrc, {tarballDir, pkgRoot}, {cwd, env, stdout, stderr,
 
   const versionResult = execa(
     'pnpm',
-    ['version', version, '--userconfig', npmrc, '--no-git-tag-version', '--allow-same-version'],
+    ['version', version, '--config', npmrc, '--no-git-tag-version', '--allow-same-version'],
     {
       cwd: basePath,
       env,
@@ -23,7 +23,7 @@ module.exports = async (npmrc, {tarballDir, pkgRoot}, {cwd, env, stdout, stderr,
 
   if (tarballDir) {
     logger.log('Creating npm package version %s', version);
-    const packResult = execa('pnpm', ['pack', basePath, '--userconfig', npmrc], {cwd, env, preferLocal: true});
+    const packResult = execa('pnpm', ['pack', basePath, '--config', npmrc], {cwd, env, preferLocal: true});
     packResult.stdout.pipe(stdout, {end: false});
     packResult.stderr.pipe(stderr, {end: false});
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -22,7 +22,7 @@ module.exports = async (npmrc, {npmPublish, pkgRoot}, pkg, context) => {
     logger.log(`Publishing version ${version} to npm registry on dist-tag ${distTag}`);
     const result = execa(
       'pnpm',
-      ['publish', basePath, '--userconfig', npmrc, '--tag', distTag, '--registry', registry],
+      ['publish', basePath, '--config', npmrc, '--tag', distTag, '--registry', registry],
       {cwd, env, preferLocal: true}
     );
     result.stdout.pipe(stdout, {end: false});

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -18,7 +18,7 @@ module.exports = async (npmrc, pkg, context) => {
 
   if (normalizeUrl(registry) === normalizeUrl(DEFAULT_NPM_REGISTRY)) {
     try {
-      const whoamiResult = execa('pnpm', ['whoami', '--userconfig', npmrc, '--registry', registry], {
+      const whoamiResult = execa('pnpm', ['whoami', '--config', npmrc, '--registry', registry], {
         cwd,
         env,
         preferLocal: true,


### PR DESCRIPTION
Fixes `--userconfig` flag error as pnpm uses `--config` (https://github.com/pnpm/pnpm/issues/40).

Example: https://github.com/jundaoapp/design/actions/runs/3983241579/jobs/6828393161#step:9:59

(Correction of #2)